### PR TITLE
Update to use Silk.NET bindings instead of Evergine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
-# .NET WebAssembly + WebGL
+# .NET WebGL sample
 
-This is a minimum viable product for running WebGL, using dotnet's BlazorWebassembly and WaveEngine's OpenGLES with emscripten, based on @emepetres's wasm sample projects.
+This is a minimum viable product for running WebGL, using dotnet's WebAssembly and Silk's OpenGLES bindings with emscripten.
 
-## Areas needing work
-
-The trimming is too excessive by default, so this workaround is needed to fix deploys:
-
-```xml
-  <ItemGroup>
-    <TrimmerRootAssembly Include="Microsoft.AspNetCore.Components.WebAssembly" />
-  </ItemGroup>
-```
-
+Thanks to WaveEngine/@emepetres's wasm sample projects for help and original samples and references.

--- a/WasmTest.csproj
+++ b/WasmTest.csproj
@@ -19,6 +19,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <TrimmableAssembly Include="Silk.NET.Maths" />
+  </ItemGroup>
+
+  <ItemGroup>
     <NativeFileReference Include="libEGL.c" ScanForPInvokes="true" />
     <NativeFileReference Include="openal32.c" ScanForPInvokes="true" />
     <NativeFileReference Include="emscripten.c" ScanForPInvokes="true" />
@@ -32,7 +36,7 @@
     <PackageReference Include="Verlite.MsBuild" Version="2.4.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.8" PrivateAssets="all" />
-    <PackageReference Include="Evergine.Bindings.OpenGL" Version="2023.2.19.1" />
+    <PackageReference Include="Silk.NET.OpenGLES" Version="2.17.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Silk.NET is open source compared to Evergine's bindings, and is quickly becoming the recommended bindings vs alternatives like OpenTK (which don't yet support WebAssembly).